### PR TITLE
Adding a style guide section with alt-text docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,15 @@ This repo contains the documentation for end users and developers of all the O-F
 
 This is a Github Pages site that uses Jekyll. You will need to [install Jekyll](https://jekyllrb.com/docs/installation/).
 
-## Building and running the app
+## Building and testing the documentation
 
 To build the documentation locally, navigate to the publishing source (where this README is) and run:
 `bundle exec jekyll serve`<BR>
 
 You can see the local site at:<BR>
 http://localhost:4000<BR>
+
+## Style guide
+
+The style guide includes notes on accessibility, and can be seen in the `style` directory.
 

--- a/_layouts/style.html
+++ b/_layouts/style.html
@@ -1,0 +1,24 @@
+---
+layout: default
+---
+<h1>{{ page.title }}</h1>
+<!-- <p class="meta">{{ page.date | date_to_string }}</p> -->
+
+<div class="post">
+  {{ content }}
+</div>
+
+<div class="PageNavigation">
+  {% if page.previous.site=='style' %}
+    {% if page.previous.url %}
+      { <a class="prev" href="{{page.previous.url}}">&laquo; {{page.previous.title}}</a> }
+    {% endif %} 
+  {% endif %} 
+  {% if page.next.site=='style' %}
+    {% if page.next.url %}
+      { <a class="next" href="{{page.next.url}}">{{page.next.title}} &raquo;</a> }
+    {% endif %}
+  {% endif %} 
+</div>
+<BR><BR>
+<A HREF="/style">Up to main style page</A> 

--- a/_posts/style/2020-10-02-Alt-Text.md
+++ b/_posts/style/2020-10-02-Alt-Text.md
@@ -1,0 +1,51 @@
+---
+layout: style
+title: "Accessibility: Alt Tags"
+date: 2020-10-02 00:00:00 -0400
+categories: style
+---
+
+Users may not be able to see images for a variety of reasons - the image link is broken, their device is not compatible, or the user has low or no vision, etc. Alt tags are used to describe an image so that users who cannot see an image can still be informed. Alt tags are even used when an image is working and visible to the user, to provide more information.<BR><BR>
+
+Alt tags should be descriptive, but not overly long. Imagine the image does not exist, and you are describing it to an illustrator who will draw it. There is no need to put "an image" or "a picture" in the description, this is already known. Likewise, there is no need to duplicate information that is in the accompanying text.<BR><BR>
+
+
+Here is an example image with its accompanying text:<BR>
+
+<div class="highlight">
+<BR>
+You then need to get the code from your new fork. Select the green "Code" button and select the copy icon to copy the code location:<BR>
+<CENTER><img src="/assets/images/GetCode.png" align='center' width="80%" style="border:1px solid black" ><BR><BR></CENTER>
+
+</div>
+
+Good Alt text: "How to get the URL to use when checking out the code."<BR><BR>
+
+If you need to, use a broken image on purpose to get an idea of how it feels:
+
+<div class="highlight">
+<BR>
+You then need to get the code from your new fork. Select the green "Code" button and select the copy icon to copy the code location:<BR>
+<img src="/assets/images/BROKEN_IMAGE_ON_PURPOSE.png" alt="How to get the URL to use when checking out the code." style="border:1px solid black" ><BR><BR>
+
+</div>
+
+This technique should illuminate why alt-text like 'fork' or 'image showing what was described' are not ideal:
+<div class="highlight">
+<BR>
+You then need to get the code from your new fork. Select the green "Code" button and select the copy icon to copy the code location:<BR>
+<img src="/assets/images/BROKEN_IMAGE_ON_PURPOSE.png" alt="clone" style="border:1px solid black" ><BR><BR>
+
+</div>
+In the above example, "clone" is not descriptive enough.
+<BR><BR>
+<div class="highlight">
+<BR>
+You then need to get the code from your new fork. Select the green "Code" button and select the copy icon to copy the code location:<BR>
+<img src="/assets/images/BROKEN_IMAGE_ON_PURPOSE.png" alt="This image shows a github repository page, with a red arrow pointing to the green 'Code' button and another red arrow pointing to the 'copy' icon." style="border:1px solid black" ><BR><BR>
+</div>
+This alt text has too many details, and is redundant with the text before it.
+
+
+
+[More alt text examples and descriptions](https://webaim.org/techniques/alttext/)

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -1,0 +1,3 @@
+.highlight {
+    background-color:rgba(0, 0, 0, 0.0470588);
+}

--- a/style/index.html
+++ b/style/index.html
@@ -1,0 +1,16 @@
+---
+layout: default
+---
+<h1>O-FISH Documentation Style Guide</h1>
+
+This is the style guide for the O-FISH App Documentation. 
+
+	<ul class="posts">
+{% assign sortedPosts = site.posts | reverse %}
+	  {% for post in sortedPosts %}
+            {% if post.categories contains 'style' %}
+	    <li><span>» <a href="{{ post.url }}" title="{{ post.title }}">{{ post.title }}</a></li>
+            {% endif %}
+	  {% endfor %}
+<BR>
+


### PR DESCRIPTION
## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- Please link to the issue by adding the issue number after the #: -->

Fixes #

## Checklist:
<!--- Please check off any appropriate boxes by replacing the whitespace with an `x` in the box -->
- [x] I have read the [contributor's guide](https://wildaid.github.io/contribute/index.html).
- [ ] I linked an issue in the previous section
- [ ] I have commented on the linked issue
- [ ] I was assigned the linked issue (not required)
- [x] I have tested the change to the best of my ability against the [sandbox](https://wildaid.github.io/contribute/sandbox.html) or a [local build](https://wildaid.github.io/build).

Optional items:
<!--- Please check off any appropriate boxes by replacing the whitespace with an `x` in the box -->
- [ ] My change adds new text and requires a change to translations.
- [ ] I was not able to test... (explain below, e.g. you did not have permissions to test a specific feature)
- [ ] This change depends O-FISH Realm repository changes (explain below)
- [ ] This change depends O-FISH Web repository changes (explain below)

* **Optional: Add any explanations here** 



* **Optional: Add any relevant screenshots here** 



