### PR TITLE
Adding alt-text tags to iOS usage pages (#61)

### DIFF
--- a/_posts/use/2020-08-01-HomeScreenI.md
+++ b/_posts/use/2020-08-01-HomeScreenI.md
@@ -11,7 +11,7 @@ site: useiOS
 
 # The Home Screen
 On the home screen, there are a few sections. The top section includes an avatar and your name ("Gabon Test" in this case) and a duty toggle - as shown, the officer is off duty). Then there is a section to do a pre-boarding search of records, a map and a button to board the vessel.<BR>
-<img src="/assets/images/use/HomePageI.png" width="50%" style="border:1px solid black"><BR><BR>
+<img src="/assets/images/use/HomePageI.png" alt="Home Screen" width="50%" style="border:1px solid black"><BR><BR>
 
 The blue dot on the map indicates your location. Also shown is your latitude and longitude in degrees, minutes and seconds. To change your location in case GPS isn't accurate, drag the map as the blue dot stays in the center. Use 2 fingers to pinch or spread to zoom in or out.
 <BR><BR>

--- a/_posts/use/2020-08-01-LoginI.md
+++ b/_posts/use/2020-08-01-LoginI.md
@@ -6,19 +6,19 @@ site: useiOS
 ---
 
 If the O-FISH application takes time to load, you may see the splash screen:<BR>
-<img src="/assets/images/use/SplashScreen.png" width="50%" style="border:1px solid black"><BR>
+<img src="/assets/images/use/SplashScreen.png" alt="O-FISH splash screen" width="50%" style="border:1px solid black"><BR>
 <BR><BR>
 O-FISH uses your location to populate the latitude and longitude in the boarding report.  The first time you open the app, you will be prompted to allow O-FISH to use your location before logging in.  Make sure to click "Allow While Using App":<BR>
 
-<img src="/assets/images/use/AllowLocationI.png" width="50%" style="border:1px solid black"><BR><BR>
+<img src="/assets/images/use/AllowLocationI.png" alt="" width="50%" style="border:1px solid black"><BR><BR>
 
 O-FISH sends you a notification when you forget to mark that you are no longer on patrol after several hours of being idle. Please click "Allow": <BR>
 
-<img src="/assets/images/use/SendNotificationsI.png" width="50%" style="border:1px solid black"><BR><BR>
+<img src="/assets/images/use/SendNotificationsI.png" alt="" width="50%" style="border:1px solid black"><BR><BR>
 
 Enter the username and password you were assigned and click the "Log In" button. 
 You can use TouchID or FaceAuth to login if you have previously logged in, by tapping the icon to the right of the Email/Username field - in the diagram below, it is pointed to with a red arrow. 
-
-<img src="/assets/images/use/LoginI.png" width="75%" style="border:1px solid black"> <BR><BR>
+0
+<img src="/assets/images/use/LoginI.png" alt="O-FISH Login Screen" width="75%" style="border:1px solid black"> <BR><BR>
 
 

--- a/_posts/use/2020-08-13-FeedbackI.md
+++ b/_posts/use/2020-08-13-FeedbackI.md
@@ -9,31 +9,31 @@ Giving feedback with O-FISH from the TestFlight app is easy. There are two-ways:
 
 <A NAME="testflight"></A>**Submit Feedback Using TestFlight**<BR><BR>
 In TestFlight, select the O-FISH app - do NOT select the "OPEN" button to open the app. Select within the green box indicated:<BR>
-<img src="/assets/images/use/TestFlightApps.PNG" width="50%" style="border:1px solid black"><BR><BR>
+<img src="/assets/images/use/TestFlightApps.PNG" alt="How to give feedback using TestFlight" width="50%" style="border:1px solid black"><BR><BR>
 
 Then select "Send Beta Feedback" as indicated by the green box:<BR>
-<img src="/assets/images/use/ChooseFeedback.PNG" width="50%" style="border:1px solid black"><BR><BR>
+<img src="/assets/images/use/ChooseFeedback.PNG" alt="Select &quot;Send Beta Feedback&quot;" width="50%" style="border:1px solid black"><BR><BR>
 
 You will be prompted to include a screenshot from your Camera Roll or not. We recommend sending screen shots via the [in app method](#inapp) as it is faster. If you choose "Include Screenshot" you will be prompted to choose an image from your camera roll and then taken to a screen to type in your feedback. If you choose "Don't Include Screenshot" you go directly to the page to type in your feedback.<BR><BR>
 On the feedback screen, type your feedback in the white box and select "Submit" in the upper-right corner when you are finished. This will send the feedback immediately.
-<img src="/assets/images/use/TypeFeedback.png" width="50%" style="border:1px solid black"><BR><BR>
+<img src="/assets/images/use/TypeFeedback.png" alt="" width="50%" style="border:1px solid black"><BR><BR>
 
 You may send as much feedback as you like - the more the better!<BR><BR>
 
 <A NAME="inapp"></a>**Submit Feedback While In the App**<BR><BR>
 You can give in-app feedback by taking a screenshot of the app, and select the screenshot when it appears in the lower-left hand corner:<BR>
 
-<img src="/assets/images/use/TapScreenshotI.jpg" width="50%" style="border:1px solid black"><BR><BR>
+<img src="/assets/images/use/TapScreenshotI.jpg" alt="How to give in-app feedback" width="50%" style="border:1px solid black"><BR><BR>
 
 Now you can draw and make marks to highlight specific areas. In this example, the feedback is the text is too small so the user circled and pointed to it:<BR>
 
-<img src="/assets/images/use/MarkupScreenshot.PNG" width="50%" style="border:1px solid black"><BR><BR>
+<img src="/assets/images/use/MarkupScreenshot.PNG" alt="How to highlight specific areas for feedback" width="50%" style="border:1px solid black"><BR><BR>
 
 Select "Done" in the upper left hand corner. You will then see a dialog asking what to do with the photo. Select "Share Beta Feedback..."<BR>
 
-<img src="/assets/images/use/ShareBeta.jpg" width="50%" style="border:1px solid black"><BR><BR>
+<img src="/assets/images/use/ShareBeta.jpg" alt="" width="50%" style="border:1px solid black"><BR><BR>
 
 Type your feedback in the box and click "Submit" in the upper-right corner when done. This will send the feedback immediately, and save the marked-up photo to your device. <BR>
-<img src="/assets/images/use/TypeFeedback.PNG" width="50%" style="border:1px solid black"><BR><BR>
+<img src="/assets/images/use/TypeFeedback.PNG" alt="" width="50%" style="border:1px solid black"><BR><BR>
 <BR><BR>
 You may send as much feedback as you like - the more the better!<BR><BR>


### PR DESCRIPTION
## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- Please link to the issue by adding the issue number after the #: -->
Add alt-text tags to iOS usage pages #61

Fixes #

## Checklist:
<!--- Please check off any appropriate boxes by replacing the whitespace with an `x` in the box -->
- [x] I have read the [contributor's guide](https://wildaid.github.io/contribute/index.html).
- [x] I linked an issue in the previous section
- [x] I have commented on the linked issue
- [x] I was assigned the linked issue (not required)
- [x] I have tested the change to the best of my ability against the [sandbox](https://wildaid.github.io/contribute/sandbox.html) or a [local build](https://wildaid.github.io/build).
- [x] All my images have [appropriate alt tags](https://wildaid.github.io/style/2020/10/02/Alt-Text.html)

Optional items:
<!--- Please check off any appropriate boxes by replacing the whitespace with an `x` in the box -->
- [ ] My change adds new text and requires a change to translations.
- [ ] I was not able to test... (explain below, e.g. you did not have permissions to test a specific feature)
- [ ] This change depends O-FISH Realm repository changes (explain below)
- [ ] This change depends O-FISH Web repository changes (explain below)

* **Optional: Add any explanations here** 



* **Optional: Add any relevant screenshots here** 



