### PR TITLE
Adding alt text to build charts overview and deploy pages (#66)

### DIFF
--- a/_posts/build_charts/2020-06-11-Build-Charts.md
+++ b/_posts/build_charts/2020-06-11-Build-Charts.md
@@ -7,10 +7,10 @@ site: build
 ---
 
 There are 6 charts to make for the O-FISH web app. There are 4 charts in the Compliance Rate section on the homepage - each of the numbers for "Compliance Rate", "Boardings" and "Violations" are their own charts, plus the donut chart:
-<img src="/assets/images/ComplianceCharts.png" style="border:1px solid black" width="100%"><BR><BR>
+<img src="/assets/images/ComplianceCharts.png" alt="The number charts are on the left and the donut chart is on the right" style="border:1px solid black" width="100%"><BR><BR>
 
 Underneath the Compliance Rate section, there is a map of boardings, and then a chart with a list of boardings:
-<img src="/assets/images/BoardingsMap.png" style="border:1px solid black" width="100%"><BR><BR>
-<img src="/assets/images/ListOfBoardings.png" style="border:1px solid black" width="100%"><BR><BR>
+<img src="/assets/images/BoardingsMap.png" alt="Interactive map color-coded by risk" style="border:1px solid black" width="100%"><BR><BR>
+<img src="/assets/images/ListOfBoardings.png" alt="6 column table filtered by date" style="border:1px solid black" width="100%"><BR><BR>
 
 First, we will set up the Data Sources and create a dashboard for our charts.

--- a/_posts/build_charts/2020-06-12-Test-Charts.md
+++ b/_posts/build_charts/2020-06-12-Test-Charts.md
@@ -9,9 +9,9 @@ site: build
 You have created and embedded a chart, so let's build and deploy the web application to see that everything worked.
 
 1. In the Realm UI in your browser, select "Hosting" on the left-hand side under "MANAGE"<BR>
-<img src="/assets/images/Hosting.png" style="border:1px solid black" width="70%"><BR><BR>
+<img src="/assets/images/Hosting.png" alt="How to get to where Hosting is located" style="border:1px solid black" width="70%"><BR><BR>
 1. You should see this page:
-<img src="/assets/images/HostingWithFiles.png" style="border:1px solid black" width="100%"><BR><BR>
+<img src="/assets/images/HostingWithFiles.png" alt="What the Hosting page looks like" style="border:1px solid black" width="100%"><BR><BR>
 
 1. Follow the <A HREF="/web/2020/06/09/Build-Web-App.html">build instructions starting at #5</a> to build and deploy the application.
 

--- a/_posts/build_charts/2020-06-14-Test-Charts.md
+++ b/_posts/build_charts/2020-06-14-Test-Charts.md
@@ -9,9 +9,9 @@ site: build
 You have created and embedded your charts, so let's build and deploy the web application to see that everything worked.
 
 1. In the Realm UI in your browser, select "Hosting" on the left-hand side under "MANAGE"<BR>
-<img src="/assets/images/Hosting.png" style="border:1px solid black" width="70%"><BR><BR>
+<img src="/assets/images/Hosting.png" alt="How to get to where Hosting is located" style="border:1px solid black" width="70%"><BR><BR>
 1. You should see this page:
-<img src="/assets/images/HostingWithFiles.png" style="border:1px solid black" width="100%"><BR><BR>
+<img src="/assets/images/HostingWithFiles.png" alt="What the Hosting page looks like" style="border:1px solid black" width="100%"><BR><BR>
 
 1. Follow the <A HREF="/web/2020/06/09/Build-Web-App.html">build instructions starting at #5</a> to build and deploy the application.
 


### PR DESCRIPTION
## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- Please link to the issue by adding the issue number after the #: -->

Fixes #66 

## Checklist:
<!--- Please check off any appropriate boxes by replacing the whitespace with an `x` in the box -->
- [x] I have read the [contributor's guide](https://wildaid.github.io/contribute/index.html).
- [x] I linked an issue in the previous section
- [x] I have commented on the linked issue
- [x] I was assigned the linked issue (not required)
- [x] I have tested the change to the best of my ability against the [sandbox](https://wildaid.github.io/contribute/sandbox.html) or a [local build](https://wildaid.github.io/build).
- [x] All my images have [appropriate alt tags](https://wildaid.github.io/style/2020/10/02/Alt-Text.html)

Optional items:
<!--- Please check off any appropriate boxes by replacing the whitespace with an `x` in the box -->
- [ ] My change adds new text and requires a change to translations.
- [ ] I was not able to test... (explain below, e.g. you did not have permissions to test a specific feature)
- [ ] This change depends O-FISH Realm repository changes (explain below)
- [ ] This change depends O-FISH Web repository changes (explain below)

* **Optional: Add any explanations here** 



* **Optional: Add any relevant screenshots here** 



